### PR TITLE
User interface updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The command line syntax is `vt100 [-f] [-D] [-R test] program/device`.
 
 <kbd>F9</kbd> is the SET-UP key.  See a [VT100 User
 Guide](https://vt100.net/docs/vt100-ug/chapter1.html) for instructions.
+<kbd>Control</kbd>+<kbd>F11</kbd> exits the simlator.
 
 ### 3D Printed Model
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The command line syntax is `vt100 [-f] [-D] [-R test] program/device`.
 - `-f` enters full screen.  Toggle with <kbd>F11</kbd>.
 - `-D` enters a PDP-10 style DDT for debugging the firmware.
 - `-R test` runs a CP/M program; this is only for testing.
+- `-C` turns capslock into control.
 - `program/device` is any command to run as a child process providing I/O,
   or a character device assumed to be a serial port.
 

--- a/vt100/main.c
+++ b/vt100/main.c
@@ -121,9 +121,10 @@ int main (int argc, char **argv)
   int opt;
 
   halt = end;
+  sdl_capslock (0x7E); //Default is capslock.
 
   argv0 = argv[0];
-  while ((opt = getopt (argc, argv, "b:Br2fR:D")) != -1) {
+  while ((opt = getopt (argc, argv, "b:Br2fR:DC")) != -1) {
     switch (opt) {
     case 'B':
       /* Backspace is Rubout. */
@@ -139,6 +140,9 @@ int main (int argc, char **argv)
       break;
     case 'D':
       debug = 1;
+      break;
+    case 'C':
+      sdl_capslock (0x7C); //Make capslock into control.
       break;
     default:
       usage();

--- a/vt100/sdl.c
+++ b/vt100/sdl.c
@@ -86,8 +86,13 @@ static void draw (struct draw *data)
 
 static void toggle_fullscreen (void)
 {
-  Uint32 flags = SDL_GetWindowFlags (window) & SDL_WINDOW_FULLSCREEN_DESKTOP;
-  SDL_SetWindowFullscreen (window, flags ^ SDL_WINDOW_FULLSCREEN_DESKTOP);
+  Uint32 flags = SDL_GetWindowFlags (window);
+  flags ^= SDL_WINDOW_FULLSCREEN_DESKTOP;
+  SDL_SetWindowFullscreen (window, flags);
+  if (flags & SDL_WINDOW_FULLSCREEN_DESKTOP)
+    SDL_ShowCursor (SDL_DISABLE);
+  else
+    SDL_ShowCursor (SDL_ENABLE);
 }
 
 void mkwindow (SDL_Window **window, SDL_Renderer **renderer,

--- a/vt100/sdl.c
+++ b/vt100/sdl.c
@@ -8,6 +8,7 @@ static u32 userevent;
 static u8 fb[TERMHEIGHT + 1][137];
 static u8 a[TERMHEIGHT + 1];
 static u8 capslock;
+static void (*meta) (void);
 
 void draw_line (int scroll, int attr, int y, u8 *data)
 {
@@ -108,6 +109,17 @@ void sdl_capslock (u8 code)
   capslock = code;
 }
 
+static void altmode (void)
+{
+  key_down (0x2A);
+  SDL_Delay (50);
+  key_up (0x2A);
+}
+
+static void nothing (void)
+{
+}
+
 void sdl_init (int scale, int full)
 {
   SDL_Init (SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_AUDIO);
@@ -119,22 +131,34 @@ void sdl_init (int scale, int full)
   userevent = SDL_RegisterEvents (1);
   memset (a, 0, sizeof a);
 
+  meta = nothing;
+
   draw_data.brightness = 0x10;
   draw_data.columns = 80;
   draw_data.renderer = renderer;
   reset_render (&draw_data);
 }
 
-static int special_key (SDL_Scancode key)
+static int special_key (SDL_KeyboardEvent *ev)
 {
-  switch (key) {
+  switch (ev->keysym.scancode) {
   case SDL_SCANCODE_F11:
+    if (ev->state != SDL_PRESSED)
+      return 1;
     if (SDL_GetModState () & KMOD_CTRL)
       exit (0);
     else
       toggle_fullscreen ();
     return 1;
-  default: return 0;
+  case SDL_SCANCODE_LALT:
+  case SDL_SCANCODE_RALT:
+    switch (ev->state) {
+    case SDL_PRESSED: meta = altmode; break;
+    case SDL_RELEASED: meta = nothing; break;
+    }
+    return 1;
+  default:
+    return 0;
   }  
 }
 
@@ -241,14 +265,17 @@ void sdl_loop (void)
     case SDL_KEYDOWN:
       if (ev.key.repeat)
         break;
-      if (special_key (ev.key.keysym.scancode))
+      if (special_key (&ev.key))
         break;
       code = keymap (ev.key.keysym.scancode);
       if (code == 0)
         break;
+      meta ();
       key_down (code);
       break;
     case SDL_KEYUP:
+      if (special_key (&ev.key))
+        break;
       key_up (keymap (ev.key.keysym.scancode));
       break;
 

--- a/vt100/sdl.c
+++ b/vt100/sdl.c
@@ -121,7 +121,12 @@ void sdl_init (int scale, int full)
 static int special_key (SDL_Scancode key)
 {
   switch (key) {
-  case SDL_SCANCODE_F11: toggle_fullscreen (); return 1;
+  case SDL_SCANCODE_F11:
+    if (SDL_GetModState () & KMOD_CTRL)
+      exit (0);
+    else
+      toggle_fullscreen ();
+    return 1;
   default: return 0;
   }  
 }

--- a/vt100/sdl.c
+++ b/vt100/sdl.c
@@ -8,17 +8,13 @@ static u32 userevent;
 static u8 fb[TERMHEIGHT + 1][137];
 static u8 a[TERMHEIGHT + 1];
 
-SDL_SpinLock lock_update;
-
 void draw_line (int scroll, int attr, int y, u8 *data)
 {
   int i;
   if ((attr | scroll) != a[y] || memcmp (data, fb[y], 80) != 0) {
-    SDL_AtomicLock(&lock_update);
     a[y] = attr | scroll;
     for (i = 0; i < 132; i++)
       fb[y][i] = data[i];
-    SDL_AtomicUnlock(&lock_update);
   }
 }
 

--- a/vt100/sdl.c
+++ b/vt100/sdl.c
@@ -7,6 +7,7 @@ static SDL_Texture *screentex;
 static u32 userevent;
 static u8 fb[TERMHEIGHT + 1][137];
 static u8 a[TERMHEIGHT + 1];
+static u8 capslock;
 
 void draw_line (int scroll, int attr, int y, u8 *data)
 {
@@ -91,8 +92,8 @@ static void toggle_fullscreen (void)
     SDL_ShowCursor (SDL_ENABLE);
 }
 
-void mkwindow (SDL_Window **window, SDL_Renderer **renderer,
-               char *title, int width, int height)
+static void mkwindow (SDL_Window **window, SDL_Renderer **renderer,
+		      char *title, int width, int height)
 {
   if (SDL_CreateWindowAndRenderer (width, height, 0, window, renderer) < 0)
     //panic("SDL_CreateWindowAndRenderer failed: %s\n", SDL_GetError ());
@@ -100,6 +101,11 @@ void mkwindow (SDL_Window **window, SDL_Renderer **renderer,
   SDL_SetWindowTitle (*window, title);
   SDL_SetHint (SDL_HINT_RENDER_SCALE_QUALITY, "linear");
   SDL_SetHint ("SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS", "0");
+}
+
+void sdl_capslock (u8 code)
+{
+  capslock = code;
 }
 
 void sdl_init (int scale, int full)
@@ -217,7 +223,7 @@ static u8 keymap (SDL_Scancode key) {
   case SDL_SCANCODE_LCTRL: return 0x7C;
   case SDL_SCANCODE_RSHIFT:
   case SDL_SCANCODE_LSHIFT: return 0x7D;
-  case SDL_SCANCODE_CAPSLOCK: return 0x7E;
+  case SDL_SCANCODE_CAPSLOCK: return capslock;
   default: return 0;
   }
 }

--- a/vt100/xsdl.h
+++ b/vt100/xsdl.h
@@ -16,4 +16,3 @@ extern void sdl_loop (void);
 extern void sdl_refresh (struct draw *data);
 extern void sdl_render (int brightness, int columns);
 extern void draw_line (int scroll, int attr, int y, u8 *data);
-extern SDL_SpinLock lock_update;

--- a/vt100/xsdl.h
+++ b/vt100/xsdl.h
@@ -16,3 +16,4 @@ extern void sdl_loop (void);
 extern void sdl_refresh (struct draw *data);
 extern void sdl_render (int brightness, int columns);
 extern void draw_line (int scroll, int attr, int y, u8 *data);
+extern void sdl_capslock (u8 code);


### PR DESCRIPTION
- Control-F11 to exit the simulation.  It's a blue pill to get out of the (keyboard) matrix.
- Hide mouse cursor in full screen mode.
- Optionally make capslock control.
- Meta generates altmode prefix.