### PR TITLE
Render fixes

### DIFF
--- a/vt100/render.c
+++ b/vt100/render.c
@@ -83,7 +83,12 @@ static unsigned widen (unsigned pixels, unsigned mask1, unsigned mask2)
 static u8 * render_80 (u8 *dest, int c, int wide, int scroll, struct draw *data)
 {
   unsigned pixels, reverse = 0;
-  pixels = vt100font[16 * (c & 0x7F) + scroll];
+
+  // FIXME: the font ROM seems slightly scrambled
+  if (scroll == 0)
+	  ++c;
+  pixels = vt100font[16 * (c & 0x7F) + scroll - 1];
+
   if (c & 0x80) {
     if (data->underline)
       pixels = scroll == 8 ? 0xFF : pixels;
@@ -93,12 +98,19 @@ static u8 * render_80 (u8 *dest, int c, int wide, int scroll, struct draw *data)
   if (data->reverse)
     reverse ^= wide ? 0xFFFFF : 0x3FF;
   pixels <<= 2;
+
+  // extend last column
   if (pixels & 4)
     pixels |= 3;
+
+  // dot stretcher
   pixels |= pixels >> 1;
+
   if (wide)
     pixels = widen (pixels, 0x200, 0xC0000);
+
   pixels ^= reverse;
+
   if (wide) {
     SDL_memcpy (dest, scanline[pixels >> 10], 10 * sizeof (u32));
     dest += 10 * sizeof (u32);
@@ -111,7 +123,12 @@ static u8 * render_80 (u8 *dest, int c, int wide, int scroll, struct draw *data)
 static u8 * render_132 (u8 *dest, int c, int wide, int scroll, struct draw *data)
 {
   unsigned pixels, reverse = 0;
-  pixels = vt100font[16 * (c & 0x7F) + scroll];
+
+  // FIXME: the font ROM seems slightly scrambled
+  if (scroll == 0)
+	  ++c;
+  pixels = vt100font[16 * (c & 0x7F) + scroll -1];
+
   if (c & 0x80) {
     if (data->underline)
       pixels = scroll == 8 ? 0xFF : pixels;
@@ -121,12 +138,19 @@ static u8 * render_132 (u8 *dest, int c, int wide, int scroll, struct draw *data
   if (data->reverse)
     reverse ^= wide ? 0x3FFFF : 0x1FF;
   pixels <<= 1;
+
+  // extend last column
   if (pixels & 2)
     pixels |= 1;
+
+  // dot stretcher
   pixels |= pixels >> 1;
+
   if (wide)
     pixels = widen (pixels, 0x200, 0xC0000);
+
   pixels ^= reverse;
+
   if (wide) {
     SDL_memcpy (dest, scanline[pixels >> 9], 6 * sizeof (u32));
     dest += 6 * sizeof (u32);


### PR DESCRIPTION
Hi, I fixed some rendering issues. First one is, the "dot stretcher" needs to happen _after_ "widening" for correct rendering of double-width chars.

Second is #28. I tried the obvious fix,  `scroll - 1`, but then it still wasn't quite right. After staring at vttest's character set screen a bit I figured out the first scanline of a cell was showing up on the _next_ char, so `if (scroll == 0) ++c;` did the trick.

I suspect the root of this is some mixed up address lines in the char gen roms? Is something clever being done in the hardware? A cleaner fix would be to re-order the rom the way the code expects, but I wanted to confer with hardware experts before doing so.

Looking at the raw bits in GIMP confirms the ROM image itself is off. As the upper row is only visible in a few special chars, this would be easy for whoever dumped the ROM to overlook.

![image](https://user-images.githubusercontent.com/8746882/125368639-8d635f00-e32f-11eb-9212-30d8ac601c9f.png)

This all looks "more correct" to me but I do not have a real VT100 or any experience with one so this should be qualified against a real one. :)

My only experience with real text terminals was Wyse terminals at the library. If anyone is working on emulating Wyse terminals, let me know. I haven't even been able to find any ROM dumps for those. :(