### PR TITLE
Make smooth scroll a little smoother

### DIFF
--- a/vt100/video.c
+++ b/vt100/video.c
@@ -9,6 +9,8 @@ static int hertz;
 static int interlace;
 static u8 line_buffer[137];
 static int line_scroll;
+// offset counter used for smooth scrolling
+static int offset_counter = 0;
 static u8 line_attr;
 
 static void refresh (void);
@@ -123,7 +125,7 @@ static u16 video_line (int n, u16 addr)
         for (i = p - line_buffer; i < columns; i++)
           *p++ = 0;
       if (n >= skip)
-        draw_line (line_scroll, line_attr & 0xE0, n - skip, line_buffer);
+        draw_line (offset_counter, line_attr & 0xE0, n - skip, line_buffer);
       line_attr = memory[addr];
       switch (line_attr & 0x60) {
       case 0x00: /*double height, bottom line*/ break;
@@ -162,11 +164,12 @@ static void refresh (void)
     addr = video_line (i, addr);
   
   draw_data.odd = interlace && (fields & 1);
-  draw_data.scroll = line_scroll;
+  draw_data.scroll = offset_counter;
   draw_data.columns = columns;
   draw_data.reverse = reverse_field;
   draw_data.underline = underline;
   sdl_refresh (&draw_data);
+  offset_counter = line_scroll;
 }
 
 void reset_video (void)


### PR DESCRIPTION
Attempt to fix issue #8.
When smooth scrolling is enabled (the default), scrolling actually "jumps" every tenth frame. It seems that the firmware does its "shuffling" operation after having set the scroll latch to 0, but after the simulator actually rendered the current lines. That causes the scroll to appear smooth for a while but at the last frame it "jumps back" at its original position for a moment.
I think the problem is that the "offset counter" used for smooth scrolling is actually loaded from the scroll latch during vertical reset (this is what I understand from the Tech reference at 4-96), but the simulator directly uses the scroll latch as immediately set by the cpu.
I changed the video source to use an `offset_counter` loaded from the `line_scroll` to simulate this behavior and the scrolling seems to be much better.
Probably this is not the definitive fix, but hope it's a step in the right direction.
