### PR TITLE
refresh only if event queue is empty

### DIFF
--- a/vt100/video.c
+++ b/vt100/video.c
@@ -154,7 +154,15 @@ static void refresh (void)
   u16 addr;
 
   raise_interrupt (4);
+
+  // only refresh if event queue is empty
+  if (SDL_PollEvent(NULL)) {
+    add_event (2764800 / hertz, &refresh_event);
+    return;
+  }
+
   add_event (2764800 / hertz, &refresh_event);
+  
 
   fields++;
   if ((fields % field_rate) != 0)


### PR DESCRIPTION
The problem with the slow down of keyboard entries on slower computers has to do with too many refresh events that have been pushed to the event queue. This fix will only refresh if the event queue is empty, e.g. no events such as keyboard events there anymore. If there are any other events there, they will be handled before the next refresh is executed.

The fix allows to run vt100 on slower computers such as the Raspberry Pi. I have checked it on a Raspberry Pi 5, with and without vnc.

No keys should be lost anymore and vt100 should not go into a state anymore in which it is extremely slow and not responsive.